### PR TITLE
Changed the Template Jenkinsfile to use Node10 Slave

### DIFF
--- a/fe-ionic/Jenkinsfile.template
+++ b/fe-ionic/Jenkinsfile.template
@@ -22,7 +22,7 @@ library identifier: 'ods-library@production', retriever: modernSCM(
   https://github.com/opendevstack/ods-project-quickstarters/tree/master/jenkins-slaves/nodejs8-angular
  */
 odsPipeline(
-  image: "${dockerRegistry}/cd/jenkins-slave-nodejs8-angular",
+  image: "${dockerRegistry}/cd/jenkins-slave-nodejs10-angular",
   projectId: projectId,
   componentId: componentId,
   branchToEnvironmentMapping: [


### PR DESCRIPTION
During testing of the quickstarters today There were no issues with building on the node10 slave image, so I would recommend that we make this default for the next release